### PR TITLE
Fix for PlotSquared v5 Events

### DIFF
--- a/src/de/Ste3et_C0st/ProtectionLib/main/plugins/fPlotsquaredV5.java
+++ b/src/de/Ste3et_C0st/ProtectionLib/main/plugins/fPlotsquaredV5.java
@@ -7,20 +7,19 @@ import java.util.UUID;
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.Listener;
 import org.bukkit.plugin.Plugin;
 
 import com.plotsquared.core.events.PlotClearEvent;
 import com.plotsquared.core.events.PlotDeleteEvent;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.plot.Plot;
+import com.plotsquared.core.api.PlotAPI;
 import com.sk89q.worldedit.util.eventbus.Subscribe;
 import de.Ste3et_C0st.ProtectionLib.events.RegionClearEvent;
 import de.Ste3et_C0st.ProtectionLib.main.ProtectionLib;
 import de.Ste3et_C0st.ProtectionLib.main.protectionObj;
 
-public class fPlotsquaredV5 extends protectionObj implements Listener{
+public class fPlotsquaredV5 extends protectionObj {
 
 	public fPlotsquaredV5(Plugin pl) {
 		super(pl);

--- a/src/de/Ste3et_C0st/ProtectionLib/main/plugins/fPlotsquaredV5.java
+++ b/src/de/Ste3et_C0st/ProtectionLib/main/plugins/fPlotsquaredV5.java
@@ -15,6 +15,7 @@ import com.plotsquared.core.events.PlotClearEvent;
 import com.plotsquared.core.events.PlotDeleteEvent;
 import com.plotsquared.core.location.Location;
 import com.plotsquared.core.plot.Plot;
+import com.sk89q.worldedit.util.eventbus.Subscribe;
 import de.Ste3et_C0st.ProtectionLib.events.RegionClearEvent;
 import de.Ste3et_C0st.ProtectionLib.main.ProtectionLib;
 import de.Ste3et_C0st.ProtectionLib.main.protectionObj;
@@ -23,10 +24,12 @@ public class fPlotsquaredV5 extends protectionObj implements Listener{
 
 	public fPlotsquaredV5(Plugin pl) {
 		super(pl);
-		Bukkit.getPluginManager().registerEvents(this, ProtectionLib.getInstance());
+		PlotAPI api = new PlotAPI();
+		
+		api.registerListener(this);
 	}
 	
-	@EventHandler
+	@Subscribe
 	private void onDelete(PlotClearEvent clearEvent) {
 		List<Location> locationList = clearEvent.getPlot().getAllCorners();
 		Location plotLocMin = locationList.get(0);
@@ -40,7 +43,7 @@ public class fPlotsquaredV5 extends protectionObj implements Listener{
 		}
 	}
 	
-	@EventHandler
+	@Subscribe
 	private void onDelete(PlotDeleteEvent clearEvent) {
 		List<Location> locationList = clearEvent.getPlot().getAllCorners();
 		Location plotLocMin = locationList.get(0);


### PR DESCRIPTION
PlotSquared v5 uses Google Guava's `@Subscriber` to subscribe to events.
You need the `@Subscribe` annotation and then register the event using the PlotAPI.